### PR TITLE
#75 Fix: Crash "Canvas: trying to draw too large bitmap (241 MB)" when zooming game board

### DIFF
--- a/app/src/main/java/at/aau/monopoly/klagenfurt/ui/zoom/ZoomableWrapper.kt
+++ b/app/src/main/java/at/aau/monopoly/klagenfurt/ui/zoom/ZoomableWrapper.kt
@@ -18,11 +18,8 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.layout.layout
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.unit.Density
-import kotlin.math.roundToInt
 
 /**
  * The current zoom scale, readable by child composables to adjust
@@ -56,9 +53,11 @@ class ZoomState(
 }
 
 @Composable
-fun ZoomableWrapper(modifier: Modifier = Modifier, content: @Composable () -> Unit) {
-    val zoomState = remember { ZoomState() }
-    val baseDensity = LocalDensity.current
+fun ZoomableWrapper(
+    modifier: Modifier = Modifier,
+    zoomState: ZoomState = remember { ZoomState() },
+    content: @Composable () -> Unit
+) {
     Box(
         modifier = modifier
             .clip(RectangleShape)
@@ -73,42 +72,25 @@ fun ZoomableWrapper(modifier: Modifier = Modifier, content: @Composable () -> Un
             }
     ) {
         CompositionLocalProvider(LocalZoomScale provides zoomState.scale) {
-            // Scale the density so that sp/dp values grow with the zoom,
-            // keeping text and spacing proportional to the enlarged layout.
-            val scaledDensity = Density(
-                density = baseDensity.density * zoomState.scale,
-                fontScale = baseDensity.fontScale
-            )
-            CompositionLocalProvider(LocalDensity provides scaledDensity) {
             Box(
                 modifier = Modifier
                     .fillMaxSize()
-                    .layout { measurable, constraints ->
-                        // Measure content at scaled-up size so vectors render
-                        // at the zoomed resolution (sharp, no bitmap upscale).
-                        val s = zoomState.scale
-                        // Guard against unbounded constraints (e.g. Constraints.Infinity)
-                        // multiplying by zoom scale, which would overflow Int.
-                        val maxW = if (constraints.hasBoundedWidth) constraints.maxWidth else 4096
-                        val maxH = if (constraints.hasBoundedHeight) constraints.maxHeight else 4096
-                        val scaledConstraints = constraints.copy(
-                            maxWidth = (maxW * s).roundToInt().coerceAtMost(16384),
-                            maxHeight = (maxH * s).roundToInt().coerceAtMost(16384)
-                        )
-                        val placeable = measurable.measure(scaledConstraints)
-                        layout(constraints.maxWidth, constraints.maxHeight) {
-                            // Centre the scaled content, then apply pan offset.
-                            val ox = ((constraints.maxWidth - placeable.width) / 2f +
-                                    zoomState.offset.x).roundToInt()
-                            val oy = ((constraints.maxHeight - placeable.height) / 2f +
-                                    zoomState.offset.y).roundToInt()
-                            placeable.place(ox, oy)
-                        }
+                    .graphicsLayer {
+                        // Use graphicsLayer (compositing-level transform) for zoom/pan.
+                        // Unlike the previous layout{} approach, this does NOT re-measure
+                        // content at inflated pixel sizes. Content always measures at
+                        // normal screen resolution. Vectors rasterize at their natural
+                        // size, and the compositing pipeline scales/translates the
+                        // already-rendered pixel buffer — preventing "Canvas: trying to
+                        // draw too large bitmap" crashes.
+                        scaleX = zoomState.scale
+                        scaleY = zoomState.scale
+                        translationX = zoomState.offset.x
+                        translationY = zoomState.offset.y
                     },
                 contentAlignment = Alignment.Center
             ) {
                 content()
-            }
             }
         }
     }

--- a/app/src/test/java/at/aau/monopoly/klagenfurt/ui/zoom/ZoomableWrapperComposeTest.kt
+++ b/app/src/test/java/at/aau/monopoly/klagenfurt/ui/zoom/ZoomableWrapperComposeTest.kt
@@ -1,0 +1,196 @@
+package at.aau.monopoly.klagenfurt.ui.zoom
+
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.example.myapplication.R
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Compose UI tests for [ZoomableWrapper] that verify it renders correctly
+ * even when parent constraints are unbounded (e.g., inside a scrollable list).
+ */
+@RunWith(AndroidJUnit4::class)
+class ZoomableWrapperComposeTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun `does not crash with unbounded height constraints in LazyColumn`() {
+        // LazyColumn provides unbounded height constraints to children,
+        // which previously caused an integer overflow when multiplied by the zoom scale.
+        composeTestRule.setContent {
+            LazyColumn {
+                item {
+                    ZoomableWrapper(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(300.dp)
+                    ) {
+                        Box(modifier = Modifier.size(100.dp))
+                    }
+                }
+            }
+        }
+        // If we reach here without crashing, the unbounded constraint guard works.
+        composeTestRule.waitForIdle()
+    }
+
+    @Test
+    fun `does not crash with unbounded width constraints`() {
+        // Using LazyRow to provide unbounded width constraints.
+        composeTestRule.setContent {
+            LazyRow {
+                item {
+                    ZoomableWrapper(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(300.dp)
+                    ) {
+                        Box(modifier = Modifier.size(100.dp))
+                    }
+                }
+            }
+        }
+        // If we reach here without crashing, the unbounded constraint guard works.
+        composeTestRule.waitForIdle()
+    }
+
+    @Test
+    fun `renders normally with bounded constraints`() {
+        // Normal use case: bounded constraints via fixed size modifier.
+        composeTestRule.setContent {
+            ZoomableWrapper(
+                modifier = Modifier.size(400.dp)
+            ) {
+                Box(modifier = Modifier.size(100.dp))
+            }
+        }
+        composeTestRule.waitForIdle()
+        // If we reach here without crashing, bounded constraints work fine.
+    }
+
+    @Test
+    fun `does not crash with large vector drawable at max zoom`() {
+        // Regression test: the original bug caused a "Canvas: trying to draw too
+        // large bitmap" crash when a vector drawable was rendered at 5× zoom.
+        // Back then, ZoomableWrapper used layout{} to re-measure content at
+        // inflated pixel sizes, causing VectorPainter to rasterize a ~241 MB
+        // bitmap. The fix uses graphicsLayer{} instead — content always measures
+        // at normal screen resolution and the compositing pipeline handles
+        // zoom/pan after rasterization.
+
+        // Pre-configure a ZoomState at max zoom (5×) with a small pan offset
+        // to verify the pan path also works.
+        val zoomState = ZoomState(initialScale = 5f, initialOffset = Offset(50f, -30f))
+
+        composeTestRule.setContent {
+            ZoomableWrapper(
+                modifier = Modifier.size(400.dp),
+                zoomState = zoomState
+            ) {
+                // pathreworked.xml has a 3840×2160 viewport — large enough
+                // to trigger the crash at inflated measure sizes.
+                Box(modifier = Modifier.fillMaxSize()) {
+                    Image(
+                        painter = painterResource(id = R.drawable.pathreworked),
+                        contentDescription = "Path - Klagenfurt-Ring",
+                        modifier = Modifier.fillMaxSize(),
+                        contentScale = ContentScale.FillBounds
+                    )
+                }
+            }
+        }
+        composeTestRule.waitForIdle()
+        // If we reach here without crashing at 5× zoom with a large vector,
+        // the fix works correctly.
+    }
+
+    @Test
+    fun `does not crash with large vector drawable at intermediate zoom levels`() {
+        // Test multiple zoom levels to ensure the fix is robust across the range.
+        // We test each zoom level in a separate @Test-method-style approach
+        // by ramping the zoomState within a single setContent call.
+        val zoomState = ZoomState(initialScale = 1f)
+        val simulateContainer = androidx.compose.ui.geometry.Size(400f, 400f)
+
+        composeTestRule.setContent {
+            ZoomableWrapper(
+                modifier = Modifier.size(400.dp),
+                zoomState = zoomState
+            ) {
+                Box(modifier = Modifier.fillMaxSize()) {
+                    Image(
+                        painter = painterResource(id = R.drawable.pathreworked),
+                        contentDescription = "Path",
+                        modifier = Modifier.fillMaxSize(),
+                        contentScale = ContentScale.FillBounds
+                    )
+                }
+            }
+        }
+        composeTestRule.waitForIdle()
+
+        // Step through increasing zoom levels
+        zoomState.updateTransformation(Offset.Zero, 3f, simulateContainer)
+        composeTestRule.waitForIdle()
+
+        zoomState.updateTransformation(Offset.Zero, 1.5f, simulateContainer)
+        composeTestRule.waitForIdle()
+
+        zoomState.updateTransformation(Offset.Zero, 5f, simulateContainer)
+        composeTestRule.waitForIdle()
+
+        // No crash at any zoom level.
+    }
+
+    @Test
+    fun `rapid zoom changes do not crash with large vector drawable`() {
+        // Simulate rapid zoom changes like pinch-gestures would produce.
+        val zoomState = ZoomState(initialScale = 1f)
+
+        composeTestRule.setContent {
+            ZoomableWrapper(
+                modifier = Modifier.size(400.dp),
+                zoomState = zoomState
+            ) {
+                Box(modifier = Modifier.fillMaxSize()) {
+                    Image(
+                        painter = painterResource(id = R.drawable.pathreworked),
+                        contentDescription = "Path",
+                        modifier = Modifier.fillMaxSize(),
+                        contentScale = ContentScale.FillBounds
+                    )
+                }
+            }
+        }
+        composeTestRule.waitForIdle()
+
+        // Simulate rapid pinch-zooming through the full range
+        val simulatePan = Offset(10f, 10f)
+        val simulateContainer = androidx.compose.ui.geometry.Size(400f, 400f)
+        for (i in 1..20) {
+            zoomState.updateTransformation(simulatePan, 1.2f, simulateContainer) // zoom in
+            zoomState.updateTransformation(simulatePan, 0.9f, simulateContainer) // zoom out slightly
+        }
+        composeTestRule.waitForIdle()
+        // If we reach here without crashing after 20 rapid zoom changes,
+        // the fix handles dynamic zoom correctly.
+    }
+}

--- a/app/src/test/java/at/aau/monopoly/klagenfurt/ui/zoom/ZoomableWrapperTest.kt
+++ b/app/src/test/java/at/aau/monopoly/klagenfurt/ui/zoom/ZoomableWrapperTest.kt
@@ -2,7 +2,9 @@ package at.aau.monopoly.klagenfurt.ui.zoom
 
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
+import kotlin.math.roundToInt
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ZoomableWrapperTest {
@@ -82,6 +84,43 @@ class ZoomableWrapperTest {
         assertEquals(100f, state.offset.y)
     }
 
+    @Test
+    fun `scaled constraint does not overflow at max zoom with infinite input`() {
+        val infinity = 0x3FFFFFFF // Constraints.Infinity internal value
+        val scale = 5f
+        val hasBounded = false
+        val safeMax = if (hasBounded) infinity else 4096
+        val result = (safeMax * scale).roundToInt().coerceAtMost(16384)
+        // Must stay positive and within safe bounds
+        assertTrue(result in 1..16384)
+    }
+
+    @Test
+    fun `scaled constraint uses bounded value when hasBoundedWidth is true`() {
+        val boundedValue = 1080
+        val scale = 5f
+        val safeMax = if (true) boundedValue else 4096
+        val result = (safeMax * scale).roundToInt().coerceAtMost(16384)
+        assertEquals(5400, result)
+    }
+
+    @Test
+    fun `layout dimensions fall back to placeable size when unbounded`() {
+        val infinity = 0x3FFFFFFF
+        val hasBounded = false
+        val placeableWidth = 2048
+        val layoutW = if (hasBounded) infinity else placeableWidth
+        assertEquals(placeableWidth, layoutW)
+    }
+
+    @Test
+    fun `layout dimensions use constraint max when bounded`() {
+        val constraintMax = 1080
+        val hasBounded = true
+        val placeableWidth = 500
+        val layoutW = if (hasBounded) constraintMax else placeableWidth
+        assertEquals(constraintMax, layoutW)
+    }
 }
 
 


### PR DESCRIPTION


**Root Cause:** 
ZoomableWrapper used a layout {} modifier that multiplied content measurement constraints by the zoom scale (up to 5×). Every child composable — including vector drawables — was re-measured at inflated pixel sizes (up to 9600×5400 px). VectorPainter then attempted to rasterize each vector into a ~241 MB bitmap, exceeding Android's maximum texture allocation, causing the fatal crash.

**Fix**
Replaced layout {} constraint scaling with graphicsLayer {} — Compose's compositing-level transform. Content now always measures at normal screen resolution, and zoom/pan is applied after rasterization by the compositing pipeline. Vectors never exceed their natural pixel budget.




commit 3e366720690d1f0b58f4ced9e627751e07f0d0f5 introduced the bug.
Closes #75