### PR TITLE
Fix overlay z-ordering, FieldCardUI zoom, and panel touch-blocking

### DIFF
--- a/app/src/main/java/at/aau/monopoly/klagenfurt/ui/GameboardUI.kt
+++ b/app/src/main/java/at/aau/monopoly/klagenfurt/ui/GameboardUI.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
@@ -314,13 +315,7 @@ fun GameboardScreen(
             }
         }
 
-        DiceRollOverlay(
-            isVisible = showOverlay,
-            diceResult = lastDiceRoll?.let { Pair(it.die1, it.die2) },
-            isRolling = isRollingPhaseForCurrentPlayer,
-            hasShaken = hasShaken,
-            onClose = { showOverlay = false }
-        )
+        GameboardOverlayLayer(eventLog = bufferedEventLog)
 
         ActionCardOverlay(
             isVisible = showActionCardOverlay,
@@ -329,7 +324,13 @@ fun GameboardScreen(
             onExecuteAction = { viewModel.executeAction() }
         )
 
-        GameboardOverlayLayer(eventLog = bufferedEventLog)
+        DiceRollOverlay(
+            isVisible = showOverlay,
+            diceResult = lastDiceRoll?.let { Pair(it.die1, it.die2) },
+            isRolling = isRollingPhaseForCurrentPlayer,
+            hasShaken = hasShaken,
+            onClose = { showOverlay = false }
+        )
 
 
     }
@@ -432,6 +433,16 @@ fun GameboardContent(
                     }
                     // Old flat PlayerToken loop removed – tokens are now rendered inside FieldItem.
                 }
+
+                
+                // Field card centered on the board — inside ZoomableWrapper so it
+                // inherits the same zoom/pan transforms as the board fields.
+                if (currentField != null) {
+                    FieldCardUI(
+                        field = currentField,
+                        modifier = Modifier.padding(8.dp)
+                    )
+                }
             }
         }
 
@@ -442,7 +453,7 @@ fun GameboardContent(
                     .align(Alignment.CenterStart)
                     .width(panelWidth)
                     .padding(start = 4.dp, top = 4.dp, bottom = 4.dp)
-                    .fillMaxHeight()
+                    .wrapContentHeight()
                     .verticalScroll(rememberScrollState()),
                 verticalArrangement = Arrangement.spacedBy(6.dp, Alignment.CenterVertically)
             ) {
@@ -458,16 +469,6 @@ fun GameboardContent(
             }
         }
 
-        // Overlay: Center – current field card
-        if (currentField != null) {
-            Box(
-                modifier = Modifier
-                    .align(Alignment.Center)
-                    .padding(8.dp)
-            ) {
-                FieldCardUI(field = currentField)
-            }
-        }
 
         // Overlay: Right panel – own player
         if (myPlayer != null) {
@@ -476,7 +477,7 @@ fun GameboardContent(
                     .align(Alignment.CenterEnd)
                     .width(panelWidth)
                     .padding(end = 4.dp, top = 4.dp, bottom = 4.dp)
-                    .fillMaxHeight()
+                    .wrapContentHeight()
                     .verticalScroll(rememberScrollState()),
                 verticalArrangement = Arrangement.Center
             ) {


### PR DESCRIPTION
**Summary:**
Resolves three UI layering issues: the chat floating above the dice overlay, FieldCardUI not zooming/panning with the board, and player info panels blocking zoom/pinch gestures.

**Changes:**

Reordered overlay rendering — GameboardOverlayLayer (chat) now renders before DiceRollOverlay and ActionCardOverlay in the outer Box. Previously the chat was the last child and drew on top of the full-screen dice overlay.

Moved FieldCardUI inside ZoomableWrapper — the field detail card now lives inside the zoomable content lambda (after    BoxWithConstraints) instead of as a separate outer overlay. It inherits the same graphicsLayer zoom/pan transforms as the board fields.

Replaced fillMaxHeight() with wrapContentHeight() on both player panel columns — the left and right panel Columns used fillMaxHeight() which made them occupy the full vertical strip (280dp wide × full screen height), intercepting all touch events and preventing zoom/pinch gestures in those regions. With wrapContentHeight(), they only block touches within their content footprint (~150dp tall), freeing roughly 80% of the screen for zoom/pan while keeping the panels clickable.
Closes #78 