### PR TITLE
 require minimum 2 players before host can start game (#81)

### DIFF
--- a/app/src/main/java/at/aau/monopoly/klagenfurt/ui/GameViewModel.kt
+++ b/app/src/main/java/at/aau/monopoly/klagenfurt/ui/GameViewModel.kt
@@ -212,13 +212,13 @@ class GameViewModel(
         .map { it != null }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
 
-    val isGameStarted: StateFlow<Boolean> = gameState
-        .map { it?.phase != null && it.phase != GamePhase.WAITING }
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
-
-    val isHost: StateFlow<Boolean> = gameState
+    val canStartGame: StateFlow<Boolean> = gameState
         .map { state ->
-            state?.players?.firstOrNull()?.id == gameService.currentPlayerId
+            val players = state?.players.orEmpty()
+            val isHost = players.firstOrNull()?.id == gameService.currentPlayerId
+            val isWaiting = state?.phase == GamePhase.WAITING
+
+            isHost && isWaiting && players.size >= 2
         }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
 

--- a/app/src/main/java/at/aau/monopoly/klagenfurt/ui/GameboardUI.kt
+++ b/app/src/main/java/at/aau/monopoly/klagenfurt/ui/GameboardUI.kt
@@ -134,8 +134,7 @@ fun GameboardScreen(
     val isRollingPhaseForCurrentPlayer by viewModel.isRollingPhaseForCurrentPlayer.collectAsState()
     val isBuyingPhaseForCurrentPlayer by viewModel.isBuyingPhaseForCurrentPlayer.collectAsState()
     val lastDiceRoll by viewModel.lastDiceRoll.collectAsState()
-    val isGameStarted by viewModel.isGameStarted.collectAsState()
-    val isHost by viewModel.isHost.collectAsState()
+    val canStartGame by viewModel.canStartGame.collectAsState()
     val cardDrawnThisTurn by viewModel.cardDrawnThisTurn.collectAsState()
 
     // Action Card states
@@ -236,7 +235,7 @@ fun GameboardScreen(
                 .padding(20.dp),
             horizontalAlignment = Alignment.End
         ) {
-            if (isHost && !isGameStarted) {
+            if (canStartGame) {
                 Button(
                     onClick = { viewModel.startGame() },
                     modifier = Modifier.padding(bottom = 8.dp)

--- a/app/src/test/java/at/aau/monopoly/klagenfurt/ui/GameViewModelTest.kt
+++ b/app/src/test/java/at/aau/monopoly/klagenfurt/ui/GameViewModelTest.kt
@@ -361,8 +361,10 @@ class GameViewModelTest {
     }
 
     @Test
-    fun `isGameStarted should be false for WAITING phase`() = runTest {
-        val job = launch { viewModel.isGameStarted.collect {} }
+    fun `canStartGame should be false for host with only 1 player in WAITING phase`() = runTest {
+        val job = launch { viewModel.canStartGame.collect {} }
+
+        fakeService.currentPlayerId = "p1"
 
         fakeService.emitTestEvent(
             """
@@ -372,7 +374,9 @@ class GameViewModelTest {
           "gameState": {
             "gameId": "g1",
             "fields": [],
-            "players": [],
+            "players": [
+              { "id": "p1", "name": "Alice" }
+            ],
             "phase": "WAITING"
           }
         }
@@ -381,40 +385,14 @@ class GameViewModelTest {
 
         advanceUntilIdle()
 
-        assertFalse(viewModel.isGameStarted.value)
+        assertFalse(viewModel.canStartGame.value)
 
         job.cancel()
     }
 
     @Test
-    fun `isGameStarted should be true for ROLLING phase`() = runTest {
-        val job = launch { viewModel.isGameStarted.collect {} }
-
-        fakeService.emitTestEvent(
-            """
-        {
-          "event": "STATE_UPDATED",
-          "gameId": "g1",
-          "gameState": {
-            "gameId": "g1",
-            "fields": [],
-            "players": [],
-            "phase": "ROLLING"
-          }
-        }
-        """.trimIndent()
-        )
-
-        advanceUntilIdle()
-
-        assertTrue(viewModel.isGameStarted.value)
-
-        job.cancel()
-    }
-
-    @Test
-    fun `isHost should be true when current player is first player`() = runTest {
-        val job = launch { viewModel.isHost.collect {} }
+    fun `canStartGame should be true for host with 2 players in WAITING phase`() = runTest {
+        val job = launch { viewModel.canStartGame.collect {} }
 
         fakeService.currentPlayerId = "p1"
 
@@ -438,14 +416,14 @@ class GameViewModelTest {
 
         advanceUntilIdle()
 
-        assertTrue(viewModel.isHost.value)
+        assertTrue(viewModel.canStartGame.value)
 
         job.cancel()
     }
 
     @Test
-    fun `isHost should be false when current player is not first player`() = runTest {
-        val job = launch { viewModel.isHost.collect {} }
+    fun `canStartGame should be false for non-host even with 2 players in WAITING phase`() = runTest {
+        val job = launch { viewModel.canStartGame.collect {} }
 
         fakeService.currentPlayerId = "p2"
 
@@ -469,7 +447,70 @@ class GameViewModelTest {
 
         advanceUntilIdle()
 
-        assertFalse(viewModel.isHost.value)
+        assertFalse(viewModel.canStartGame.value)
+
+        job.cancel()
+    }
+
+    @Test
+    fun `canStartGame should be false for host with 2 players in ROLLING phase`() = runTest {
+        val job = launch { viewModel.canStartGame.collect {} }
+
+        fakeService.currentPlayerId = "p1"
+
+        fakeService.emitTestEvent(
+            """
+        {
+          "event": "STATE_UPDATED",
+          "gameId": "g1",
+          "gameState": {
+            "gameId": "g1",
+            "fields": [],
+            "players": [
+              { "id": "p1", "name": "Alice" },
+              { "id": "p2", "name": "Bob" }
+            ],
+            "phase": "ROLLING"
+          }
+        }
+        """.trimIndent()
+        )
+
+        advanceUntilIdle()
+
+        assertFalse(viewModel.canStartGame.value)
+
+        job.cancel()
+    }
+
+    @Test
+    fun `canStartGame should be true for host with 3 players in WAITING phase`() = runTest {
+        val job = launch { viewModel.canStartGame.collect {} }
+
+        fakeService.currentPlayerId = "p1"
+
+        fakeService.emitTestEvent(
+            """
+        {
+          "event": "STATE_UPDATED",
+          "gameId": "g1",
+          "gameState": {
+            "gameId": "g1",
+            "fields": [],
+            "players": [
+              { "id": "p1", "name": "Alice" },
+              { "id": "p2", "name": "Bob" },
+              { "id": "p3", "name": "Charlie" }
+            ],
+            "phase": "WAITING"
+          }
+        }
+        """.trimIndent()
+        )
+
+        advanceUntilIdle()
+
+        assertTrue(viewModel.canStartGame.value)
 
         job.cancel()
     }


### PR DESCRIPTION
- Replace `isGameStarted` and `isHost` StateFlows with consolidated `canStartGame` flow
- Host can only start game when: is host + phase is WAITING + at least 2 players joined
- Update `GameboardUI` to use `canStartGame` for Start button visibility
- Add 5 new unit tests covering canStartGame scenarios

Closes #81 