### PR TITLE
Feature/report cheating players

### DIFF
--- a/app/src/main/java/at/aau/monopoly/klagenfurt/SettingsActivity.kt
+++ b/app/src/main/java/at/aau/monopoly/klagenfurt/SettingsActivity.kt
@@ -147,7 +147,7 @@ fun SettingsScreen(onBackClicked: () -> Unit) {
             },
             text = {
                 Text(
-                    text = "Press the Volume Up button during your turn to automatically roll a double 6!",
+                    text = "Press the Volume Up button during your turn to automatically roll a double 6! But beware: if opponents catch and report you, you'll pay a 500M fine!",
                     color = Color.White.copy(alpha = 0.9f),
                     fontSize = 16.sp
                 )

--- a/app/src/main/java/at/aau/monopoly/klagenfurt/model/Player.kt
+++ b/app/src/main/java/at/aau/monopoly/klagenfurt/model/Player.kt
@@ -9,8 +9,9 @@ data class Player(
     var inJail: Boolean = false,
     var jailTurns: Int = 0,
     var getOutOfJailCards: Int = 0,
-    var consecutiveDoublets: Int = 0, // Zählt die Paschs im aktuellen Zug
+    var consecutiveDoublets: Int = 0, // Counts doubles rolled in the current turn
     var eliminated: Boolean = false,
+    var hasCheated: Boolean = false,  // Indicates if the player cheated on their last roll
     val ownedPropertyIds: MutableList<Int> = mutableListOf()
 ) {
     /** Returns true if the player is bankrupt (no money and no properties). */

--- a/app/src/main/java/at/aau/monopoly/klagenfurt/networking/GameService.kt
+++ b/app/src/main/java/at/aau/monopoly/klagenfurt/networking/GameService.kt
@@ -47,18 +47,18 @@ interface GameService {
     fun buyProperty(fieldId: Int)
 
     fun buyHouse(fieldId: Int)
-
     fun sellHouse(fieldId: Int)
-
     fun buyHotel(fieldId: Int)
-
     fun sellHotel(fieldId: Int)
-
 
     fun payRent(fieldId: Int?, diceTotal: Int = 0)
     fun mortgageProperty(fieldId: Int)
     fun unmortgageProperty(fieldId: Int)
     fun declareBankruptcy()
+
+    // Feature: Report cheating
+    fun reportCheater(reportedPlayerId: String)
+
     /** DEBUG remove this block of code to remove */
     fun debugForwardGame()
     /** DEBUG remove this block of code to remove */

--- a/app/src/main/java/at/aau/monopoly/klagenfurt/networking/GameStompClient.kt
+++ b/app/src/main/java/at/aau/monopoly/klagenfurt/networking/GameStompClient.kt
@@ -280,7 +280,6 @@ class GameStompClient(
         }
     }
 
-
     override fun subscribeToLobby() {
         lobbyChannel.subscribe()
     }
@@ -722,6 +721,20 @@ class GameStompClient(
         )
         sendRaw("/app/game/action", JacksonProvider.objectMapper.writeValueAsString(action))
         Log.d("GameStomp", "Declaring bankruptcy")
+    }
+
+    override fun reportCheater(reportedPlayerId: String) {
+        Log.d("GameStomp", "Reporting cheater: $reportedPlayerId")
+        val action = GameAction(
+            gameId = _currentGameId,
+            playerId = currentPlayerId,
+            action = "REPORT_CHEATER",
+            payload = mapOf(
+                "reportedPlayerId" to reportedPlayerId
+            )
+        )
+        val json = JacksonProvider.objectMapper.writeValueAsString(action)
+        sendRaw("/app/game/action", json)
     }
 
     /** DEBUG remove this block of code to remove */

--- a/app/src/main/java/at/aau/monopoly/klagenfurt/networking/ServerConfig.kt
+++ b/app/src/main/java/at/aau/monopoly/klagenfurt/networking/ServerConfig.kt
@@ -6,8 +6,8 @@ import androidx.compose.runtime.setValue
 
 object ServerConfig {
 
-    //private const val LOCAL_URI = "ws://10.0.2.2:8080/ws"
-    private const val LOCAL_URI = "ws://localhost:8080/ws"
+    private const val LOCAL_URI = "ws://10.0.2.2:8080/ws"
+    //private const val LOCAL_URI = "ws://localhost:8080/ws"
     private const val GLOBAL_URI = "ws://se2-demo.aau.at:53208/ws"
 
     var isGlobal by mutableStateOf(false)

--- a/app/src/main/java/at/aau/monopoly/klagenfurt/networking/ServerConfig.kt
+++ b/app/src/main/java/at/aau/monopoly/klagenfurt/networking/ServerConfig.kt
@@ -6,8 +6,8 @@ import androidx.compose.runtime.setValue
 
 object ServerConfig {
 
-    private const val LOCAL_URI = "ws://10.0.2.2:8080/ws"
-    //private const val LOCAL_URI = "ws://localhost:8080/ws"
+    //private const val LOCAL_URI = "ws://10.0.2.2:8080/ws"
+    private const val LOCAL_URI = "ws://localhost:8080/ws"
     private const val GLOBAL_URI = "ws://se2-demo.aau.at:53208/ws"
 
     var isGlobal by mutableStateOf(false)

--- a/app/src/main/java/at/aau/monopoly/klagenfurt/ui/GameViewModel.kt
+++ b/app/src/main/java/at/aau/monopoly/klagenfurt/ui/GameViewModel.kt
@@ -26,10 +26,12 @@ import at.aau.monopoly.klagenfurt.ui.util.toManageableProperty
 import kotlin.math.ceil
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.launchIn
@@ -92,6 +94,10 @@ class GameViewModel(
 
     private val _errorMessage = MutableStateFlow<String?>(null)
     val errorMessage: StateFlow<String?> = _errorMessage.asStateFlow()
+
+    // NEW: Stream for UI Toasts (Drama Events)
+    private val _dramaEvent = MutableSharedFlow<String>()
+    val dramaEvent: SharedFlow<String> = _dramaEvent.asSharedFlow()
 
     private var errorToken: Long = 0
 
@@ -172,6 +178,11 @@ class GameViewModel(
                     gameService.currentGameId.isBlank()
                 ) {
                     gameService.setGameId(event.gameId)
+                }
+
+                // NEW: Trigger cheater events to UI
+                if (event.event == "CHEATER_REPORTED" || event.event == "CHEATER_REPORT_FAILED") {
+                    event.message?.let { msg -> _dramaEvent.emit(msg) }
                 }
 
                 // Capture old state before updating, then remember the new state.
@@ -259,8 +270,6 @@ class GameViewModel(
                         _pendingDoubleAutoEnd.value = true
                     }
                 }
-
-
 
                 if (event.event == "ERROR") {
                     showTransientError(event.message ?: "An unknown error occurred")
@@ -469,7 +478,8 @@ class GameViewModel(
                     !bankruptcyConfirm &&
                     !hasPending
         }
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
+
     val diceResultForCurrentPlayer: StateFlow<DiceRoll?> = gameState
         .map { state ->
             if (
@@ -535,7 +545,7 @@ class GameViewModel(
         if (player == null || amount <= 0) false
         else player.money >= amount
     }
-    .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
 
     // Whether total assets (cash + mortgage value + building sellback) cover the rent,
     // computed by the backend to avoid duplicated logic drift.
@@ -723,6 +733,11 @@ class GameViewModel(
 
     fun setGameId(gameId: String) = gameService.setGameId(gameId)
 
+    // NEW: Pass report to GameService
+    fun reportCheater(reportedPlayerId: String) {
+        gameService.reportCheater(reportedPlayerId)
+    }
+
     private fun updatePendingPaymentState(state: GameState?) {
         if (state == null) {
             Log.d("GameViewModel", "updatePendingPaymentState: state=null, clearing fieldId")
@@ -819,8 +834,6 @@ class GameViewModel(
             "TURN_ENDED" -> "Turn ended"
             "STATE_UPDATED" -> "Game state updated"
             "STATE_SNAPSHOT" -> "State snapshot synced"
-
-
             "JAIL_FINE_PAID" -> "Bail paid: 50M"
             "JAIL_CARD_USED" -> "Used 'Get out of jail free' card"
             "PLAYER_JAILED" -> "Player went to jail!"
@@ -830,6 +843,9 @@ class GameViewModel(
             "RENT_PAID" -> "Rent paid"
             "PAYMENT_FAILED" -> "Payment failed"
             "BANKRUPTCY_DECLARED" -> "Player went bankrupt!"
+            // NEW: Fallback strings for report events
+            "CHEATER_REPORTED" -> "🚨 Cheater successfully reported!"
+            "CHEATER_REPORT_FAILED" -> "🚨 False cheater accusation!"
             else -> eventType.replace("_", " ")
                 .lowercase()
                 .replaceFirstChar { it.uppercase() }

--- a/app/src/main/java/at/aau/monopoly/klagenfurt/ui/GameboardUI.kt
+++ b/app/src/main/java/at/aau/monopoly/klagenfurt/ui/GameboardUI.kt
@@ -80,6 +80,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filter
 import android.view.KeyEvent
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.lifecycle.ViewModel
 import at.aau.monopoly.klagenfurt.model.field.ChanceField
 import at.aau.monopoly.klagenfurt.model.field.CommunityChestField
 import kotlin.math.hypot

--- a/app/src/main/java/at/aau/monopoly/klagenfurt/ui/GameboardUI.kt
+++ b/app/src/main/java/at/aau/monopoly/klagenfurt/ui/GameboardUI.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.pm.ActivityInfo
 import android.os.Bundle
 import android.util.Log
+import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
@@ -18,10 +19,12 @@ import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.BoxWithConstraintsScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -80,7 +83,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filter
 import android.view.KeyEvent
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.lifecycle.ViewModel
 import at.aau.monopoly.klagenfurt.model.field.ChanceField
 import at.aau.monopoly.klagenfurt.model.field.CommunityChestField
 import kotlin.math.hypot
@@ -107,10 +109,10 @@ class GameboardUI : ComponentActivity() {
 
     override fun onKeyDown(keyCode: Int, event: KeyEvent?): Boolean {
         if (keyCode == KeyEvent.KEYCODE_VOLUME_UP) {
-            // Cheat im ViewModel aktivieren
+            // Activate cheat in ViewModel
             viewModel.activateCheatForNextRoll()
             Log.d("DiceDebug", "Cheat activated via Volume Up!")
-            // WICHTIG: true zurückgeben, damit sich die Lautstärke nicht ändert
+            // IMPORTANT: Return true so volume doesn't change
             return true
         }
         return super.onKeyDown(keyCode, event)
@@ -138,6 +140,15 @@ fun GameboardScreen(
     viewModel: GameViewModel,
     shakeEventsOverride: Flow<Unit>? = null
 ) {
+    val context = LocalContext.current
+
+    // NEW: Listen to drama events (cheater reports) and show Toast
+    LaunchedEffect(Unit) {
+        viewModel.dramaEvent.collect { msg ->
+            Toast.makeText(context, msg, Toast.LENGTH_LONG).show()
+        }
+    }
+
     LaunchedEffect(Unit) {
         viewModel.syncGameboardEntryState()
     }
@@ -202,8 +213,6 @@ fun GameboardScreen(
     val bankruptcyTotalDebt by viewModel.bankruptcyTotalDebt.collectAsState()
     val bankruptcyPropertiesOwned by viewModel.bankruptcyPropertiesOwned.collectAsState()
     val hasPendingPayment by viewModel.hasPendingPayment.collectAsState()
-
-    val context = LocalContext.current
 
     var showOverlay by remember { mutableStateOf(false) }
 
@@ -360,6 +369,8 @@ fun GameboardScreen(
                 selectedPlayerForOverlay = selectedPlayer,
                 onDismissOverlay = { viewModel.hidePlayerOverlay() },
                 movementAnimationState = movementState,
+                // NEW: Pass reportCheater to the content layer
+                onReportCheater = { reportedPlayerId -> viewModel.reportCheater(reportedPlayerId) },
                 modifier = Modifier.fillMaxSize()
             )
 
@@ -386,7 +397,7 @@ fun GameboardScreen(
                     if (currentTurnPlayer.inJail) {
 
                         Text(
-                            text = "🔒 Im Gefängnis (Versuch ${currentTurnPlayer.jailTurns + 1}/3)",
+                            text = "🔒 In Jail (Attempt ${currentTurnPlayer.jailTurns + 1}/3)",
                             modifier = Modifier
                                 .background(
                                     Color.Black.copy(alpha = 0.35f),
@@ -401,7 +412,7 @@ fun GameboardScreen(
                             enabled = currentTurnPlayer.money >= 50,
                             modifier = Modifier.width(buttonWidth).testTag("pay_jail_fine_button")
                         ) {
-                            Text("💰 50 M zahlen")
+                            Text("💰 Pay 50 M")
                         }
 
 
@@ -410,7 +421,7 @@ fun GameboardScreen(
                                 onClick = { viewModel.useJailCard() },
                                 modifier = Modifier.width(buttonWidth).testTag("use_jail_card_button")
                             ) {
-                                Text("🃏 Karte nutzen (${currentTurnPlayer.getOutOfJailCards})")
+                                Text("🃏 Use Card (${currentTurnPlayer.getOutOfJailCards})")
                             }
                         }
 
@@ -419,7 +430,7 @@ fun GameboardScreen(
                             onClick = { showOverlay = true },
                             modifier = Modifier.width(buttonWidth).testTag("roll_dice_button")
                         ) {
-                            Text("🎲 Pasch versuchen")
+                            Text("🎲 Attempt Double")
                         }
                     } else {
                         GlassButton(
@@ -594,33 +605,33 @@ fun GameboardScreen(
             )
         }
 
-            // Back button animated from top
-            val activity = context as? Activity
-            val backOffsetYDp = backButtonOffsetY.value.dp
-            GlassButton(
-                onClick = { activity?.finish() },
-                modifier = Modifier
-                    .align(Alignment.TopStart)
-                    .padding(16.dp)
-                    .offset(y = backOffsetYDp)
-            ) {
-                Icon(
-                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                    contentDescription = "Back",
-                    tint = Color.White,
-                    modifier = Modifier.size(18.dp)
-                )
-                Spacer(modifier = Modifier.width(6.dp))
-                Text(
-                    text = "Back",
-                    fontSize = 14.sp,
-                    color = Color.White,
-                    fontWeight = FontWeight.Medium,
-                    letterSpacing = 1.sp
-                )
-            }
+        // Back button animated from top
+        val activity = context as? Activity
+        val backOffsetYDp = backButtonOffsetY.value.dp
+        GlassButton(
+            onClick = { activity?.finish() },
+            modifier = Modifier
+                .align(Alignment.TopStart)
+                .padding(16.dp)
+                .offset(y = backOffsetYDp)
+        ) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                contentDescription = "Back",
+                tint = Color.White,
+                modifier = Modifier.size(18.dp)
+            )
+            Spacer(modifier = Modifier.width(6.dp))
+            Text(
+                text = "Back",
+                fontSize = 14.sp,
+                color = Color.White,
+                fontWeight = FontWeight.Medium,
+                letterSpacing = 1.sp
+            )
         }
     }
+}
 
 /**
  * Shape that clips to a circle expanding from center based on [progress] (0..1).
@@ -646,104 +657,107 @@ internal class CircularRevealShape(private val progress: Float) : androidx.compo
     }
 }
 
-    @Composable
-    fun BoxScope.GameboardOverlayLayer(eventLog: List<GameViewModel.LogEntry>) {
-        ChatOverlay(
-            entries = eventLog,
-            modifier = Modifier.align(Alignment.TopCenter)
-        )
+@Composable
+fun BoxScope.GameboardOverlayLayer(eventLog: List<GameViewModel.LogEntry>) {
+    ChatOverlay(
+        entries = eventLog,
+        modifier = Modifier.align(Alignment.TopCenter)
+    )
+}
+
+@Composable
+fun GameboardContent(
+    fields: List<Field>,
+    players: List<Player> = emptyList(),
+    currentPlayerId: String = "",
+    currentTurnPlayer: Player? = null,
+    onPlayerCardClick: (Player) -> Unit = {},
+    selectedPlayerForOverlay: Player? = null,
+    onDismissOverlay: () -> Unit = {},
+    movementAnimationState: MovementAnimationState? = null,
+    onReportCheater: (String) -> Unit = {}, // NEW: Report Lambda
+    modifier: Modifier = Modifier
+) {
+    val myPlayer = players.find { it.id == currentPlayerId }
+    val otherPlayers = players.filter { it.id != currentPlayerId }
+
+    val currentField = currentTurnPlayer?.let { p ->
+        fields.getOrNull(p.position)
     }
 
-    @Composable
-    fun GameboardContent(
-        fields: List<Field>,
-        players: List<Player> = emptyList(),
-        currentPlayerId: String = "",
-        currentTurnPlayer: Player? = null,
-        onPlayerCardClick: (Player) -> Unit = {},
-        selectedPlayerForOverlay: Player? = null,
-        onDismissOverlay: () -> Unit = {},
-        movementAnimationState: MovementAnimationState? = null,
-        modifier: Modifier = Modifier
-    ) {
-        val myPlayer = players.find { it.id == currentPlayerId }
-        val otherPlayers = players.filter { it.id != currentPlayerId }
+    val playersByField: Map<Int, List<Player>> = remember(players) {
+        players.groupBy { it.position }
+    }
 
-        val currentField = currentTurnPlayer?.let { p ->
-            fields.getOrNull(p.position)
-        }
+    BoxWithConstraints(modifier = modifier.fillMaxSize()) {
+        val panelWidth = maxWidth * 0.32f
+        val panelMargin = 8.dp
+        // Board layer (zoomable)
+        ZoomableWrapper(modifier = Modifier.fillMaxSize()) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .aspectRatio(3840f / 2160f),
+                contentAlignment = Alignment.Center
+            ) {
+                BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+                    val sw = this.maxWidth.value
+                    val sh = this.maxHeight.value
 
-        val playersByField: Map<Int, List<Player>> = remember(players) {
-            players.groupBy { it.position }
-        }
+                    FullscreenImage(R.drawable.background, "Klagenfurt-Map")
+                    // Semi-transparent warm overlay to match field backgrounds
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .background(Color(0xFFFFF3E0).copy(alpha = 0.40f))
+                    )
 
-        BoxWithConstraints(modifier = modifier.fillMaxSize()) {
-            val panelWidth = maxWidth * 0.32f
-            val panelMargin = 8.dp
-            // Board layer (zoomable)
-            ZoomableWrapper(modifier = Modifier.fillMaxSize()) {
-                Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .aspectRatio(3840f / 2160f),
-                    contentAlignment = Alignment.Center
-                ) {
-                    BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
-                        val sw = this.maxWidth.value
-                        val sh = this.maxHeight.value
-
-                        FullscreenImage(R.drawable.background, "Klagenfurt-Map")
-                        // Semi-transparent warm overlay to match field backgrounds
-                        Box(
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .background(Color(0xFFFFF3E0).copy(alpha = 0.40f))
-                        )
-
-                        fields.forEachIndexed { index, field ->
-                            key(field.id) {
-                                FieldItem(
-                                    index = index,
-                                    field = field,
-                                    sw = sw,
-                                    sh = sh,
-                                    playersOnField = playersByField[field.id] ?: emptyList(),
-                                    animatingPlayerId = movementAnimationState?.playerId,
-                                    animatingStep = movementAnimationState?.let {
-                                        if (it.currentStepIndex in it.path.indices) it.path[it.currentStepIndex] else null
-                                    },
-                                    animationComplete = movementAnimationState?.isComplete ?: true
-                                )
-                            }
-                        }
-                    }
-
-
-                    // Field card centered on the board
-                    if (currentField != null) {
-                        BoxWithConstraints {
-                            val cw = (maxWidth * 0.12f).coerceAtMost(140.dp)
-                            val ch = cw * (224f / 140f)
-                            FieldCardUI(
-                                field = currentField,
-                                cardWidth = cw,
-                                cardHeight = ch,
-                                modifier = Modifier.padding(8.dp)
+                    fields.forEachIndexed { index, field ->
+                        key(field.id) {
+                            FieldItem(
+                                index = index,
+                                field = field,
+                                sw = sw,
+                                sh = sh,
+                                playersOnField = playersByField[field.id] ?: emptyList(),
+                                animatingPlayerId = movementAnimationState?.playerId,
+                                animatingStep = movementAnimationState?.let {
+                                    if (it.currentStepIndex in it.path.indices) it.path[it.currentStepIndex] else null
+                                },
+                                animationComplete = movementAnimationState?.isComplete ?: true
                             )
                         }
                     }
                 }
-            }
 
-            // Overlay: Left panel – other players
-            if (otherPlayers.isNotEmpty()) {
-                PlayerPanel(
-                    alignment = Alignment.CenterStart,
-                    panelWidth = panelWidth,
-                    panelMargin = panelMargin,
-                    verticalArrangement = Arrangement.spacedBy(6.dp, Alignment.CenterVertically)
-                ) {
-                    otherPlayers.forEach { player ->
+
+                // Field card centered on the board
+                if (currentField != null) {
+                    BoxWithConstraints {
+                        val cw = (maxWidth * 0.12f).coerceAtMost(140.dp)
+                        val ch = cw * (224f / 140f)
+                        FieldCardUI(
+                            field = currentField,
+                            cardWidth = cw,
+                            cardHeight = ch,
+                            modifier = Modifier.padding(8.dp)
+                        )
+                    }
+                }
+            }
+        }
+
+        // Overlay: Left panel – other players
+        if (otherPlayers.isNotEmpty()) {
+            PlayerPanel(
+                alignment = Alignment.CenterStart,
+                panelWidth = panelWidth,
+                panelMargin = panelMargin,
+                verticalArrangement = Arrangement.spacedBy(6.dp, Alignment.CenterVertically)
+            ) {
+                otherPlayers.forEach { player ->
+                    // NEW: Wrap PlayerInfo in a Column to add the Report Button below it
+                    Column(horizontalAlignment = Alignment.End) {
                         PlayerInfoPanel(
                             player = player,
                             fields = fields,
@@ -751,118 +765,131 @@ internal class CircularRevealShape(private val progress: Float) : androidx.compo
                             isCurrentTurn = player.id == currentTurnPlayer?.id,
                             onCardClick = { onPlayerCardClick(player) }
                         )
+
+                        // NEW: 🚨 Report Button
+                        Button(
+                            onClick = { onReportCheater(player.id) },
+                            modifier = Modifier
+                                .padding(top = 4.dp, end = 4.dp)
+                                .height(26.dp),
+                            contentPadding = PaddingValues(horizontal = 8.dp, vertical = 0.dp),
+                            colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFAA0000)),
+                            shape = RoundedCornerShape(6.dp)
+                        ) {
+                            Text("🚨 Report", fontSize = 11.sp, color = Color.White, fontWeight = FontWeight.Bold)
+                        }
                     }
                 }
             }
+        }
 
 
-            // Overlay: Right panel – own player
-            if (myPlayer != null) {
-                PlayerPanel(
-                    alignment = Alignment.CenterEnd,
-                    panelWidth = panelWidth,
-                    panelMargin = panelMargin,
-                    verticalArrangement = Arrangement.Center
-                ) {
-                    PlayerInfoPanel(
-                        player = myPlayer,
-                        fields = fields,
-                        cards = emptyList(),
-                        isCurrentTurn = myPlayer.id == currentTurnPlayer?.id,
-                        isOwnPlayer = true,
-                        onCardClick = { onPlayerCardClick(myPlayer) }
-                    )
-                }
-            }
-
-            // Player Property Overlay
-            selectedPlayerForOverlay?.let { player ->
-                PlayerPropertyOverlay(
-                    player = player,
-                    allFields = fields,
-                    onDismiss = onDismissOverlay
+        // Overlay: Right panel – own player
+        if (myPlayer != null) {
+            PlayerPanel(
+                alignment = Alignment.CenterEnd,
+                panelWidth = panelWidth,
+                panelMargin = panelMargin,
+                verticalArrangement = Arrangement.Center
+            ) {
+                PlayerInfoPanel(
+                    player = myPlayer,
+                    fields = fields,
+                    cards = emptyList(),
+                    isCurrentTurn = myPlayer.id == currentTurnPlayer?.id,
+                    isOwnPlayer = true,
+                    onCardClick = { onPlayerCardClick(myPlayer) }
                 )
             }
         }
-    }
 
-    /**
-     * Semi-transparent rounded button used throughout the gameboard UI.
-     */
-    @Composable
-    private fun GlassButton(
-        onClick: () -> Unit,
-        modifier: Modifier = Modifier,
-        enabled: Boolean = true,
-        content: @Composable RowScope.() -> Unit
-    ) {
-        Button(
-            onClick = onClick,
-            modifier = modifier,
-            enabled = enabled,
-            colors = ButtonDefaults.buttonColors(
-                containerColor = Color.Black.copy(alpha = 0.35f),
-                contentColor = Color.White
-            ),
-            shape = RoundedCornerShape(12.dp),
-            content = content
-        )
-    }
-
-    /**
-     * Draw-card button used for Chance and Community Chest fields.
-     */
-    @Composable
-    private fun DrawCardButton(
-        cardType: String,
-        alreadyDrawn: Boolean,
-        enabled: Boolean,
-        label: String,
-        onDraw: () -> Unit,
-        modifier: Modifier = Modifier
-    ) {
-        GlassButton(
-            onClick = onDraw,
-            enabled = enabled && !alreadyDrawn,
-            modifier = modifier
-        ) {
-            Text(if (alreadyDrawn) "✓ Card Drawn" else label)
+        // Player Property Overlay
+        selectedPlayerForOverlay?.let { player ->
+            PlayerPropertyOverlay(
+                player = player,
+                allFields = fields,
+                onDismiss = onDismissOverlay
+            )
         }
     }
+}
 
-    /**
-     * Scrollable side panel used for player info on left/right edges of the gameboard.
-     */
-    @Composable
-    private fun BoxWithConstraintsScope.PlayerPanel(
-        alignment: Alignment,
-        panelWidth: androidx.compose.ui.unit.Dp,
-        panelMargin: androidx.compose.ui.unit.Dp,
-        verticalArrangement: Arrangement.Vertical,
-        content: @Composable ColumnScope.() -> Unit
+/**
+ * Semi-transparent rounded button used throughout the gameboard UI.
+ */
+@Composable
+private fun GlassButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    content: @Composable RowScope.() -> Unit
+) {
+    Button(
+        onClick = onClick,
+        modifier = modifier,
+        enabled = enabled,
+        colors = ButtonDefaults.buttonColors(
+            containerColor = Color.Black.copy(alpha = 0.35f),
+            contentColor = Color.White
+        ),
+        shape = RoundedCornerShape(12.dp),
+        content = content
+    )
+}
+
+/**
+ * Draw-card button used for Chance and Community Chest fields.
+ */
+@Composable
+private fun DrawCardButton(
+    cardType: String,
+    alreadyDrawn: Boolean,
+    enabled: Boolean,
+    label: String,
+    onDraw: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    GlassButton(
+        onClick = onDraw,
+        enabled = enabled && !alreadyDrawn,
+        modifier = modifier
     ) {
-        Column(
-            modifier = Modifier
-                .align(alignment)
-                .width(panelWidth)
-                .padding(panelMargin)
-                .wrapContentHeight()
-                .verticalScroll(rememberScrollState()),
-            verticalArrangement = verticalArrangement,
-            content = content
-        )
+        Text(if (alreadyDrawn) "✓ Card Drawn" else label)
     }
+}
 
-    /**
-     * Full-size image layer used for board background layers.
-     */
-    @Composable
-    private fun FullscreenImage(@androidx.annotation.DrawableRes resId: Int, description: String) {
-        Image(
-            painter = painterResource(id = resId),
-            contentDescription = description,
-            modifier = Modifier.fillMaxSize(),
-            contentScale = ContentScale.FillBounds
-        )
-    }
+/**
+ * Scrollable side panel used for player info on left/right edges of the gameboard.
+ */
+@Composable
+private fun BoxWithConstraintsScope.PlayerPanel(
+    alignment: Alignment,
+    panelWidth: androidx.compose.ui.unit.Dp,
+    panelMargin: androidx.compose.ui.unit.Dp,
+    verticalArrangement: Arrangement.Vertical,
+    content: @Composable ColumnScope.() -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .align(alignment)
+            .width(panelWidth)
+            .padding(panelMargin)
+            .wrapContentHeight()
+            .verticalScroll(rememberScrollState()),
+        verticalArrangement = verticalArrangement,
+        content = content
+    )
+}
 
+/**
+ * Full-size image layer used for board background layers.
+ */
+@Composable
+private fun FullscreenImage(@androidx.annotation.DrawableRes resId: Int, description: String) {
+    Image(
+        painter = painterResource(id = resId),
+        contentDescription = description,
+        modifier = Modifier.fillMaxSize(),
+        contentScale = ContentScale.FillBounds
+    )
+}

--- a/app/src/test/java/at/aau/monopoly/klagenfurt/FakeGameService.kt
+++ b/app/src/test/java/at/aau/monopoly/klagenfurt/FakeGameService.kt
@@ -260,6 +260,10 @@ class FakeGameService : GameService {
 
     override fun useJailCard(){}
 
+    override fun reportCheater(reportedPlayerId: String) {
+        // Mock implementation for testing
+    }
+
     fun emitGameState(gameState: GameState) {
         val event = GameEvent(
             gameId = gameState.gameId,

--- a/app/src/test/java/at/aau/monopoly/klagenfurt/FakeGameService.kt
+++ b/app/src/test/java/at/aau/monopoly/klagenfurt/FakeGameService.kt
@@ -260,8 +260,13 @@ class FakeGameService : GameService {
 
     override fun useJailCard(){}
 
+
+    var reportCheaterCalled = false
+    var lastReportedPlayerId = ""
+
     override fun reportCheater(reportedPlayerId: String) {
-        // Mock implementation for testing
+        reportCheaterCalled = true
+        lastReportedPlayerId = reportedPlayerId
     }
 
     fun emitGameState(gameState: GameState) {

--- a/app/src/test/java/at/aau/monopoly/klagenfurt/GameStompClientTest.kt
+++ b/app/src/test/java/at/aau/monopoly/klagenfurt/GameStompClientTest.kt
@@ -1808,4 +1808,32 @@ class GameStompClientTest {
         }
     }
 
+    @Test
+    fun reportCheater_sends_report_cheater_action_with_target_id() = runTest(testDispatcher) {
+        coEvery { stompClient.connect(any<String>()) } returns stompSession
+        coEvery { stompSession.subscribeText(any<String>()) } returns flowOf()
+        coEvery { stompSession.sendText(any<String>(), any<String>()) } returns mockk()
+
+        gameStompClient.connect()
+        advanceUntilIdle()
+        gameStompClient.setGameId("game-1")
+
+        val suspectedCheaterId = "player-42"
+
+        gameStompClient.reportCheater(suspectedCheaterId)
+        advanceUntilIdle()
+
+        verify { Log.d("GameStomp", "Reporting cheater: $suspectedCheaterId") }
+
+        coVerify {
+            stompSession.sendText(
+                "/app/game/action",
+                match {
+                    it.contains("\"action\":\"REPORT_CHEATER\"") &&
+                            it.contains("\"reportedPlayerId\":\"$suspectedCheaterId\"")
+                }
+            )
+        }
+    }
+
 }

--- a/app/src/test/java/at/aau/monopoly/klagenfurt/networking/GameServiceTest.kt
+++ b/app/src/test/java/at/aau/monopoly/klagenfurt/networking/GameServiceTest.kt
@@ -45,6 +45,7 @@ class GameServiceTest {
 
         override fun payJailFine() {}
         override fun useJailCard() {}
+        override fun reportCheater(reportedPlayerId: String) {}
 
         override suspend fun createGame(
             playerName: String,

--- a/app/src/test/java/at/aau/monopoly/klagenfurt/ui/GameViewModelTest.kt
+++ b/app/src/test/java/at/aau/monopoly/klagenfurt/ui/GameViewModelTest.kt
@@ -1768,4 +1768,60 @@ class GameViewModelTest {
 
         job.cancel()
     }
+
+
+
+    @Test
+    fun `reportCheater should delegate to gameService`() {
+        val suspectId = "player-99"
+
+        viewModel.reportCheater(suspectId)
+
+        assertTrue(fakeService.reportCheaterCalled)
+        assertEquals(suspectId, fakeService.lastReportedPlayerId)
+    }
+
+    @Test
+    fun `CHEATER_REPORTED event emits message to dramaEvent flow`() = runTest {
+        val dramaMessages = mutableListOf<String>()
+        val job = launch { viewModel.dramaEvent.collect { dramaMessages.add(it) } }
+
+        val testMessage = "Alice successfully reported Bob for cheating!"
+
+        fakeService.emitTestEvent("""
+        {
+          "event": "CHEATER_REPORTED",
+          "gameId": "g1",
+          "message": "$testMessage"
+        }
+        """.trimIndent())
+
+        advanceUntilIdle()
+
+        assertTrue("Expected dramaEvent to emit the message", dramaMessages.contains(testMessage))
+
+        job.cancel()
+    }
+
+    @Test
+    fun `CHEATER_REPORT_FAILED event emits message to dramaEvent flow`() = runTest {
+        val dramaMessages = mutableListOf<String>()
+        val job = launch { viewModel.dramaEvent.collect { dramaMessages.add(it) } }
+
+        val testMessage = "Alice falsely accused Bob of cheating!"
+
+        fakeService.emitTestEvent("""
+        {
+          "event": "CHEATER_REPORT_FAILED",
+          "gameId": "g1",
+          "message": "$testMessage"
+        }
+        """.trimIndent())
+
+        advanceUntilIdle()
+
+        assertTrue("Expected dramaEvent to emit the message", dramaMessages.contains(testMessage))
+
+        job.cancel()
+    }
 }

--- a/app/src/test/java/at/aau/monopoly/klagenfurt/ui/GameboardScreenCoverageTest.kt
+++ b/app/src/test/java/at/aau/monopoly/klagenfurt/ui/GameboardScreenCoverageTest.kt
@@ -71,7 +71,7 @@ class GameboardScreenCoverageTest {
         composeTestRule.waitForIdle()
 
         // Jail status text
-        composeTestRule.onNodeWithText("🔒 Im Gefängnis (Versuch 2/3)", substring = true).assertIsDisplayed()
+        composeTestRule.onNodeWithText("🔒 In Jail (Attempt 2/3)", substring = true).assertIsDisplayed()
         // Pay fine button
         composeTestRule.onNodeWithTag("pay_jail_fine_button").assertExists()
         // Roll dice (Pasch versuchen)
@@ -110,7 +110,7 @@ class GameboardScreenCoverageTest {
         composeTestRule.waitForIdle()
 
         composeTestRule.onNodeWithTag("use_jail_card_button").assertExists()
-        composeTestRule.onNodeWithText("🃏 Karte nutzen (2)").assertIsDisplayed()
+        composeTestRule.onNodeWithText("🃏 Use Card (2)").assertIsDisplayed()
     }
 
     @Test

--- a/app/src/test/java/at/aau/monopoly/klagenfurt/ui/SettingsActivityTest.kt
+++ b/app/src/test/java/at/aau/monopoly/klagenfurt/ui/SettingsActivityTest.kt
@@ -94,7 +94,7 @@ class SettingsActivityTest {
         composeTestRule.onNodeWithText("Show Cheating Tutorial").performClick()
 
         composeTestRule.onNodeWithText("Cheat Code").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Press the Volume Up button during your turn to automatically roll a double 6!").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Press the Volume Up button during your turn to automatically roll a double 6! But beware: if opponents catch and report you, you'll pay a 500M fine!").assertIsDisplayed()
         composeTestRule.onNodeWithText("Got it").assertIsDisplayed()
     }
 


### PR DESCRIPTION
## Description
This PR implements the frontend logic for the new Cheater Reporting feature, adapting to the recent Spring Boot backend updates. Players can now accuse opponents of using the "Volume Up" dice cheat. Correct accusations reward the reporter with 500M from the cheater, while false accusations penalize the reporter with a 500M fine.

## Changes
* **Model:** Added the `hasCheated` boolean flag to `Player.kt` (defaults to false to handle Jackson serialization).
* **Networking:** Added `reportCheater(reportedPlayerId)` to `GameService` and implemented the STOMP message payload (`REPORT_CHEATER`) in `GameStompClient.kt`.
* **State Management:** Introduced a `dramaEvent` SharedFlow in `GameViewModel.kt` to catch and propagate `CHEATER_REPORTED` and `CHEATER_REPORT_FAILED` events without blocking the main game state flow.
* **UI:** * Added a "🚨 Report" button under opponent player cards in `GameboardUI`.
  * Implemented a Toast notification collector for the `dramaEvent` to broadcast the drama to the lobby.
  * Updated the Volume Up cheat description to explicitly warn users about the 500M fine.
* **Refactoring:** Translated remaining legacy German comments in the modified files to English.

